### PR TITLE
Update imageblock.info

### DIFF
--- a/imageblock.info
+++ b/imageblock.info
@@ -2,7 +2,7 @@ name = Image Block
 description = Provides a file field in block configuration form for displaying an image in a block.
 backdrop = 1.x
 type = module
-package = User interface
+package = User Interface
 dependencies[] = image
 dependencies[] = system (>=1.14.0)
 


### PR DESCRIPTION
The .info file has the package as: -

package = User interface

It should be

package = User Interface

The above leads to two "User Interface" options when using the "Module Filter" module.

See the documentation at https://docs.backdropcms.org/creating-modules

"Capitalization is important because package string is case sensitive and using package = fields in one module and package = Fields in another would yield two different packages on the module administration page. This can be highly confusing as Seven (the default administrative theme) capitalizes fieldset legends, making fields and Fields indistinguishable. Using package = Fields is the correct way."